### PR TITLE
fix: handle dict sorting in _get_alarm_data to prevent KeyError

### DIFF
--- a/custom_components/diveracontrol/sensor_entity.py
+++ b/custom_components/diveracontrol/sensor_entity.py
@@ -455,12 +455,10 @@ class DiveraLastAlarmSensor(BaseDiveraEntity):
 
     def _get_alarm_data(self) -> dict[str, Any] | None:
         """Get alarm data safely, return None if alarm doesn't exist."""
-
-        try:
-            last_alarm_id = self.coordinator.data.get(D_ALARM, {}).get(
-                "sorting", [None]
-            )[0]
-        except IndexError:
+        sorting = self.coordinator.data.get(D_ALARM, {}).get("sorting")
+        if isinstance(sorting, list) and sorting:
+            last_alarm_id = sorting[0]
+        else:
             last_alarm_id = None
 
         if last_alarm_id is None:


### PR DESCRIPTION
Fixed the bug described in issue #127.

## What was wrong
The  method assumed  was always a list. It used  after setting a default of . When the Divera API returns  as a dict (e.g. ), indexing it with  raises . The existing try/except only caught , not .

## How I fixed it
Replaced the try/except IndexError block with an explicit  check. This handles:
-  is a non-empty list → use  ✓
-  is an empty list → set to None ✓
-  is a dict → set to None ✓
-  is None → set to None ✓

Also rewrote the function to avoid the nested indexing pattern, making the logic clearer.

## Testing
- Syntax check: passed
- No existing tests cover this code path (sorting returned as dict in coordinator data)
- The fix is backward-compatible — all existing list-based behavior is preserved